### PR TITLE
Abort installation if a process spawned by lichen fails

### DIFF
--- a/crates/installer/src/steps/mod.rs
+++ b/crates/installer/src/steps/mod.rs
@@ -4,9 +4,11 @@
 
 //! Lichen installation steps
 
+use std::{fmt::Debug, process::ExitStatus};
+use thiserror::Error;
+
 mod context;
 pub use context::Context;
-use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -18,6 +20,9 @@ pub enum Error {
 
     #[error("no mountpoint given")]
     NoMountpoint,
+
+    #[error("command `{program}` exited with {status}")]
+    CommandFailed { program: String, status: ExitStatus },
 }
 
 #[derive(Debug)]
@@ -155,7 +160,6 @@ impl<'a> Step<'a> {
 }
 
 mod partitions;
-use std::fmt::Debug;
 
 pub use partitions::{BindMount, FormatPartition, MountPartition, Unmount};
 

--- a/lichen_cli/src/main.rs
+++ b/lichen_cli/src/main.rs
@@ -38,7 +38,11 @@ impl<'a> Context<'a> for CliContext {
     /// Run a step command
     /// Right now all output is dumped to stdout/stderr
     fn run_command(&self, cmd: &mut Command) -> Result<(), installer::steps::Error> {
-        let _ = cmd.spawn()?.wait();
+        let status = cmd.spawn()?.wait()?;
+        if !status.success() {
+            let program = cmd.get_program().to_string_lossy().into();
+            return Err(installer::steps::Error::CommandFailed { program, status });
+        }
         Ok(())
     }
 


### PR DESCRIPTION
I came across this when patching in support for `mkfs.xfs`, which refuses to format a partition that already has a filesystem on it if you don't pass `-f`. However, there's of course many more reasons that an external command can fail, and we shouldn't just swallow those errors!