### PR TITLE
Use fs-err for better filesystem-related error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +739,7 @@ dependencies = [
 name = "installer"
 version = "0.1.0"
 dependencies = [
+ "fs-err",
  "futures",
  "human_bytes",
  "libc",
@@ -1402,6 +1413,7 @@ dependencies = [
 name = "system"
 version = "0.1.0"
 dependencies = [
+ "fs-err",
  "futures",
  "gpt",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono-tz = "0.9.0"
 color-eyre = { version = "0.6.3", features = ["issue-url"] }
 crossterm = { version = "0.27.0", features = ["serde", "event-stream"] }
 human_bytes = "0.4.3"
+fs-err = { version = "2.11.0", features = ["tokio"] }
 futures = "0.3.30"
 libc = "0.2.155"
 log = "0.4.22"

--- a/crates/installer/Cargo.toml
+++ b/crates/installer/Cargo.toml
@@ -14,3 +14,4 @@ system = { path = "../system" }
 thiserror.workspace = true
 tokio.workspace = true
 topology.workspace = true
+fs-err.workspace = true

--- a/crates/installer/src/steps/partitions.rs
+++ b/crates/installer/src/steps/partitions.rs
@@ -6,8 +6,9 @@
 
 use std::path::PathBuf;
 
+use fs_err::tokio as fs;
 use system::disk::Partition;
-use tokio::{fs::create_dir_all, process::Command};
+use tokio::process::Command;
 
 use super::Context;
 
@@ -67,7 +68,7 @@ impl<'a> MountPartition<'a> {
         );
 
         // Ensure target exists
-        create_dir_all(&self.mountpoint).await?;
+        fs::create_dir_all(&self.mountpoint).await?;
         let source = self.partition.path.to_string_lossy().to_string();
         let dest = self.mountpoint.to_string_lossy().to_string();
         let mut cmd = Command::new("mount");
@@ -101,7 +102,7 @@ impl<'a> BindMount {
         log::info!("Bind mounting {} to {}", self.source.display(), self.dest.display());
 
         // Ensure target exists
-        create_dir_all(&self.dest).await?;
+        fs::create_dir_all(&self.dest).await?;
         let source = self.source.to_string_lossy().to_string();
         let dest = self.dest.to_string_lossy().to_string();
         let mut cmd = Command::new("mount");

--- a/crates/installer/src/steps/postinstall.rs
+++ b/crates/installer/src/steps/postinstall.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Display;
 
+use fs_err::tokio as fs;
 use system::locale::Locale;
 use tokio::process::Command;
 
@@ -93,7 +94,7 @@ impl<'a> SetLocale<'a> {
     pub(super) async fn execute(&self, context: &'a impl Context<'a>) -> Result<(), Error> {
         let contents = format!("LANG={}\n", self.locale.name);
         let path = context.root().join("etc").join("locale.conf");
-        tokio::fs::write(path, &contents).await?;
+        fs::write(path, &contents).await?;
 
         Ok(())
     }
@@ -115,7 +116,7 @@ impl<'a> SetMachineID {
     pub(super) async fn execute(&self, context: &'a impl Context<'a>) -> Result<(), Error> {
         let file = context.root().join("etc").join("machine-id");
         if file.exists() {
-            tokio::fs::remove_file(file).await?;
+            fs::remove_file(file).await?;
         }
 
         let mut cmd = Command::new("chroot");
@@ -240,7 +241,7 @@ impl<'a> EmitFstab {
     pub(super) async fn execute(&self, context: &'a impl Context<'a>) -> Result<(), Error> {
         let file = context.root().join("etc").join("fstab");
         let entries = self.entries.iter().map(|e| e.to_string()).collect::<Vec<_>>();
-        tokio::fs::write(file, entries.join("\n")).await?;
+        fs::write(file, entries.join("\n")).await?;
         Ok(())
     }
 }

--- a/crates/system/Cargo.toml
+++ b/crates/system/Cargo.toml
@@ -12,3 +12,4 @@ tokio-stream.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 superblock.workspace = true
+fs-err.workspace = true

--- a/crates/system/src/disk/partition.rs
+++ b/crates/system/src/disk/partition.rs
@@ -5,10 +5,10 @@
 //! Partition APIs
 
 use std::fmt::Display;
-use std::fs;
 use std::io::{Cursor, Read};
 use std::path::PathBuf;
 
+use fs_err as fs;
 use gpt::disk::LogicalBlockSize;
 use gpt::partition_types;
 

--- a/crates/system/src/locale/registry.rs
+++ b/crates/system/src/locale/registry.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use tokio::fs;
+use fs_err::tokio as fs;
 
 use super::{iso_3166, iso_639_2, iso_639_3, Error, Language, Locale, Territory};
 


### PR DESCRIPTION
From its [docs](https://docs.rs/fs-err/latest/fs_err/):

---

fs-err is a drop-in replacement for `std::fs` that provides more
helpful messages on errors. Extra information includes which operations was
attempted and any involved paths.

# Error Messages

Using `std::fs`, if this code fails:

```rust
let file = File::open("does not exist.txt")?;
```

The error message that Rust gives you isn't very useful:

```txt
The system cannot find the file specified. (os error 2)
```

...but if we use fs-err instead, our error contains more actionable information:

```txt
failed to open file `does not exist.txt`
    caused by: The system cannot find the file specified. (os error 2)
```