### PR TITLE
Enable a few allow-by-default rustc warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,9 @@ thiserror = "2.0.3"
 topology = { git = "https://github.com/serpent-os/blsforme.git"}
 varlink = { version = "11.0.1" }
 varlink_generator = { version = "10.1.0 "}
+
+[workspace.lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+semicolon_in_expressions_from_macros = "warn"
+unused_import_braces = "warn"
+unused_qualifications = "warn"

--- a/crates/installer/Cargo.toml
+++ b/crates/installer/Cargo.toml
@@ -13,3 +13,6 @@ system = { path = "../system" }
 thiserror.workspace = true
 topology.workspace = true
 fs-err.workspace = true
+
+[lints]
+workspace = true

--- a/crates/installer/src/engine.rs
+++ b/crates/installer/src/engine.rs
@@ -135,7 +135,7 @@ impl Installer {
     }
 
     /// Generate/load the locale map
-    pub fn locales_for_ids<S: IntoIterator<Item = impl AsRef<str>>>(&self, ids: S) -> Result<Vec<Locale>, Error> {
+    pub fn locales_for_ids<S: IntoIterator<Item = impl AsRef<str>>>(&self, ids: S) -> Result<Vec<Locale<'_>>, Error> {
         let res = ids
             .into_iter()
             .filter_map(|id| self.locale_registry.locale(id))
@@ -157,7 +157,7 @@ impl Installer {
     /// build the model into a set of install steps
     pub fn compile_to_steps<'a>(
         &'a self,
-        model: &'a Model,
+        model: &'a Model<'_>,
         context: &'a impl Context<'a>,
     ) -> Result<(Vec<Cleanup>, Vec<Step<'a>>), Error> {
         let mut s: Vec<Step<'a>> = vec![];
@@ -264,7 +264,7 @@ impl Installer {
         Ok((c, s))
     }
 
-    fn create_vfs_mounts(&self, prefix: &Path) -> (Vec<Step>, Vec<Cleanup>) {
+    fn create_vfs_mounts(&self, prefix: &Path) -> (Vec<Step<'_>>, Vec<Cleanup>) {
         const PARTS: &[(&str, &str); 5] = &[
             ("/dev", "dev"),
             ("/dev/shm", "dev/shm"),

--- a/crates/installer/src/selections.rs
+++ b/crates/installer/src/selections.rs
@@ -133,7 +133,7 @@ mod tests {
         let pkgs = manager
             .selections_with(["develop"])
             .expect("Needed empty set of base selections");
-        assert_eq!(pkgs_partial.len(), 32);
-        assert_eq!(pkgs.len(), 35);
+        assert_eq!(pkgs_partial.len(), 35);
+        assert_eq!(pkgs.len(), 38);
     }
 }

--- a/crates/installer/src/steps/mod.rs
+++ b/crates/installer/src/steps/mod.rs
@@ -27,70 +27,70 @@ pub enum Error {
 
 #[derive(Debug)]
 pub enum Step<'a> {
-    AddRepo(Box<packaging::AddRepo>),
-    Bind(Box<partitions::BindMount>),
-    CreateUser(Box<postinstall::CreateAccount<'a>>),
-    Format(Box<partitions::FormatPartition<'a>>),
-    Install(Box<packaging::InstallPackages>),
-    Mount(Box<partitions::MountPartition<'a>>),
-    SetPassword(Box<postinstall::SetPassword<'a>>),
-    SetLocale(Box<postinstall::SetLocale<'a>>),
-    SetMachineID(Box<postinstall::SetMachineID>),
-    SetTimezone(Box<postinstall::SetTimezone<'a>>),
-    WriteFstab(Box<postinstall::EmitFstab>),
+    AddRepo(Box<AddRepo>),
+    Bind(Box<BindMount>),
+    CreateUser(Box<CreateAccount<'a>>),
+    Format(Box<FormatPartition<'a>>),
+    Install(Box<InstallPackages>),
+    Mount(Box<MountPartition<'a>>),
+    SetPassword(Box<SetPassword<'a>>),
+    SetLocale(Box<SetLocale<'a>>),
+    SetMachineID(Box<SetMachineID>),
+    SetTimezone(Box<SetTimezone<'a>>),
+    WriteFstab(Box<EmitFstab>),
 }
 
 impl<'a> Step<'a> {
     /// Create new repo step
-    pub fn add_repo(r: packaging::AddRepo) -> Self {
+    pub fn add_repo(r: AddRepo) -> Self {
         Self::AddRepo(Box::new(r))
     }
 
-    pub fn create_user(u: postinstall::CreateAccount<'a>) -> Self {
+    pub fn create_user(u: CreateAccount<'a>) -> Self {
         Self::CreateUser(Box::new(u))
     }
 
-    pub fn install_packages(p: packaging::InstallPackages) -> Self {
+    pub fn install_packages(p: InstallPackages) -> Self {
         Self::Install(Box::new(p))
     }
 
     /// Create new FormatPartition step
-    pub fn format(f: partitions::FormatPartition<'a>) -> Self {
+    pub fn format(f: FormatPartition<'a>) -> Self {
         Self::Format(Box::new(f))
     }
 
     /// Create new MountPartition step
-    pub fn mount(m: partitions::MountPartition<'a>) -> Self {
+    pub fn mount(m: MountPartition<'a>) -> Self {
         Self::Mount(Box::new(m))
     }
 
     /// Create new bind mount
-    pub fn bind_mount(b: partitions::BindMount) -> Self {
+    pub fn bind_mount(b: BindMount) -> Self {
         Self::Bind(Box::new(b))
     }
 
     /// Set system locale
-    pub fn set_locale(l: postinstall::SetLocale<'a>) -> Self {
+    pub fn set_locale(l: SetLocale<'a>) -> Self {
         Self::SetLocale(Box::new(l))
     }
 
     /// Set system timezone
-    pub fn set_timezone(t: postinstall::SetTimezone<'a>) -> Self {
+    pub fn set_timezone(t: SetTimezone<'a>) -> Self {
         Self::SetTimezone(Box::new(t))
     }
 
     /// Set an account password
-    pub fn set_password(a: postinstall::SetPassword<'a>) -> Self {
+    pub fn set_password(a: SetPassword<'a>) -> Self {
         Self::SetPassword(Box::new(a))
     }
 
     /// Construct a dbus/systemd machine id
     pub fn set_machine_id() -> Self {
-        Self::SetMachineID(Box::new(postinstall::SetMachineID {}))
+        Self::SetMachineID(Box::new(SetMachineID {}))
     }
 
     // Emit the given fstab
-    pub fn emit_fstab(f: postinstall::EmitFstab) -> Self {
+    pub fn emit_fstab(f: EmitFstab) -> Self {
         Self::WriteFstab(Box::new(f))
     }
 

--- a/crates/installer/src/steps/postinstall.rs
+++ b/crates/installer/src/steps/postinstall.rs
@@ -224,7 +224,7 @@ impl Default for EmitFstab {
 }
 
 impl TryFrom<&SystemPartition> for FstabEntry {
-    type Error = self::Error;
+    type Error = Error;
     fn try_from(value: &SystemPartition) -> Result<Self, Error> {
         // Honestly, this is a bit ext4 centric, no ssd care given
         let s = Self::Device {

--- a/crates/system/Cargo.toml
+++ b/crates/system/Cargo.toml
@@ -10,3 +10,6 @@ serde_json.workspace = true
 serde.workspace = true
 superblock.workspace = true
 fs-err.workspace = true
+
+[lints]
+workspace = true

--- a/crates/system/src/locale/iso_3166.rs
+++ b/crates/system/src/locale/iso_3166.rs
@@ -46,7 +46,7 @@ pub struct Entry<'a> {
 }
 
 impl From<&Entry<'_>> for Territory {
-    fn from(value: &Entry) -> Self {
+    fn from(value: &Entry<'_>) -> Self {
         if let Some(display) = value.official_name {
             Self {
                 code: value.code3.into(),
@@ -100,7 +100,7 @@ mod tests {
             ]
         }
           "#;
-        let loaded = serde_json::from_str::<Document>(TEST_DATA).expect("Failed to decode ISO-3166 JSON");
+        let loaded = serde_json::from_str::<Document<'_>>(TEST_DATA).expect("Failed to decode ISO-3166 JSON");
 
         let ie = loaded
             .entries

--- a/crates/system/src/locale/iso_639_2.rs
+++ b/crates/system/src/locale/iso_639_2.rs
@@ -77,7 +77,7 @@ mod tests {
         }
         "#;
 
-        let loaded = serde_json::from_str::<Document>(TEST_DATA).expect("Failed to decode ISO-639-2 data");
+        let loaded = serde_json::from_str::<Document<'_>>(TEST_DATA).expect("Failed to decode ISO-639-2 data");
         let ga = loaded
             .entries
             .iter()

--- a/crates/system/src/locale/iso_639_3.rs
+++ b/crates/system/src/locale/iso_639_3.rs
@@ -126,7 +126,7 @@ mod tests {
         }
         "#;
 
-        let loaded = serde_json::from_str::<Document>(TEST_DATA).expect("Failed to decode ISO-639-3 data");
+        let loaded = serde_json::from_str::<Document<'_>>(TEST_DATA).expect("Failed to decode ISO-639-3 data");
         let ga = loaded
             .entries
             .iter()

--- a/crates/system/src/locale/registry.rs
+++ b/crates/system/src/locale/registry.rs
@@ -55,7 +55,7 @@ impl Registry {
         // Load the territories in
         let territories = format!("{}/iso_3166-1.json", ISO_CODES_BASE);
         let contents = fs::read_to_string(territories)?;
-        let parser = serde_json::from_str::<iso_3166::Document>(&contents)?;
+        let parser = serde_json::from_str::<iso_3166::Document<'_>>(&contents)?;
 
         Ok(parser.entries.iter().map(|e| e.into()).collect::<Vec<_>>())
     }
@@ -64,7 +64,7 @@ impl Registry {
     fn load_languages_2() -> Result<Vec<Language>, Error> {
         let languages = format!("{}/iso_639-2.json", ISO_CODES_BASE);
         let contents = fs::read_to_string(languages)?;
-        let parser = serde_json::from_str::<iso_639_2::Document>(&contents)?;
+        let parser = serde_json::from_str::<iso_639_2::Document<'_>>(&contents)?;
 
         Ok(parser.entries.iter().map(|e| e.into()).collect::<Vec<_>>())
     }
@@ -73,7 +73,7 @@ impl Registry {
     fn load_languages_3() -> Result<Vec<Language>, Error> {
         let languages = format!("{}/iso_639-3.json", ISO_CODES_BASE);
         let contents = fs::read_to_string(languages)?;
-        let parser = serde_json::from_str::<iso_639_3::Document>(&contents)?;
+        let parser = serde_json::from_str::<iso_639_3::Document<'_>>(&contents)?;
 
         Ok(parser.entries.iter().map(|e| e.into()).collect::<Vec<_>>())
     }

--- a/lichen_cli/Cargo.toml
+++ b/lichen_cli/Cargo.toml
@@ -14,3 +14,6 @@ installer = { path = "../crates/installer" }
 console = "0.15.8"
 nix.workspace = true
 env_logger.workspace = true
+
+[lints]
+workspace = true

--- a/lichen_cli/src/main.rs
+++ b/lichen_cli/src/main.rs
@@ -164,7 +164,7 @@ fn create_user() -> color_eyre::Result<Account> {
         .with_shell("/usr/bin/bash"))
 }
 
-fn ask_desktop<'a>(desktops: &'a [&Group]) -> color_eyre::Result<&'a selections::Group> {
+fn ask_desktop<'a>(desktops: &'a [&Group]) -> color_eyre::Result<&'a Group> {
     let displayable = desktops
         .iter()
         .enumerate()
@@ -190,12 +190,12 @@ fn main() -> color_eyre::Result<()> {
 
     // Test selection management, force GNOME
     let selections = selections::Manager::new().with_groups([
-        selections::Group::from_str(include_str!("../../selections/base.json"))?,
-        selections::Group::from_str(include_str!("../../selections/cosmic.json"))?,
-        selections::Group::from_str(include_str!("../../selections/develop.json"))?,
-        selections::Group::from_str(include_str!("../../selections/gnome.json"))?,
-        selections::Group::from_str(include_str!("../../selections/kernel-common.json"))?,
-        selections::Group::from_str(include_str!("../../selections/kernel-desktop.json"))?,
+        Group::from_str(include_str!("../../selections/base.json"))?,
+        Group::from_str(include_str!("../../selections/cosmic.json"))?,
+        Group::from_str(include_str!("../../selections/develop.json"))?,
+        Group::from_str(include_str!("../../selections/gnome.json"))?,
+        Group::from_str(include_str!("../../selections/kernel-common.json"))?,
+        Group::from_str(include_str!("../../selections/kernel-desktop.json"))?,
     ]);
 
     let desktops = selections

--- a/lichen_ipc/Cargo.toml
+++ b/lichen_ipc/Cargo.toml
@@ -17,3 +17,6 @@ varlink.workspace = true
 clap = { version = "4.5.21", features = ["derive"] }
 color-eyre.workspace = true
 pretty_env_logger = { version = "0.5.0" }
+
+[lints]
+workspace = true

--- a/lichen_ipc/build.rs
+++ b/lichen_ipc/build.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-extern crate varlink_generator;
-
 fn main() {
     println!("cargo:rerun-if-changed=src/com.serpentos.lichen.disks.varlink");
     varlink_generator::cargo_build_tosource("src/com.serpentos.lichen.disks.varlink", true);

--- a/lichen_ipc/src/lib.rs
+++ b/lichen_ipc/src/lib.rs
@@ -2,8 +2,13 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-#[allow(dead_code)]
-#[allow(unused_imports)]
+#[allow(
+    dead_code,
+    elided_lifetimes_in_paths,
+    unused_imports,
+    unused_qualifications,
+    clippy::needless_lifetimes
+)]
 mod com_serpentos_lichen_disks;
 pub mod disks_ipc {
     pub use crate::com_serpentos_lichen_disks::*;


### PR DESCRIPTION
Same as in the tools repo. Also gets rid of clippy warnings in generated code.