### PR TITLE
Notify users for internet connection before installation

### DIFF
--- a/lichen_cli/src/main.rs
+++ b/lichen_cli/src/main.rs
@@ -236,7 +236,7 @@ fn main() -> color_eyre::Result<()> {
         partition_detection_warning
     ))?;
 
-    cliclack::log::warning("Make sure you have an active internet connection to downloads packages.")?;
+    cliclack::log::warning("Make sure you have an active internet connection to download packages.")?;
 
     let should_continue =
         cliclack::confirm("Have you set up partitions according to the above requirements?").interact()?;


### PR DESCRIPTION
As discussed in the #73 about a short message for notifying users to have an active internet connection before proceeding. I added a short message after the partition warning.