### PR TITLE
Update Cosmic description in lichen installation process

### DIFF
--- a/selections/cosmic.json
+++ b/selections/cosmic.json
@@ -1,12 +1,10 @@
 {
   "name": "cosmic",
   "summary": "COSMIC Desktop",
-  "description": "Warning: Provided as an alpha preview",
+  "description": "Stable: But still under active development",
   "display": true,
   "priority": 30,
-  "depends": [
-    "base-desktop"
-  ],
+  "depends": ["base-desktop"],
   "required": [
     "cosmic-applets",
     "cosmic-bg",

--- a/selections/cosmic.json
+++ b/selections/cosmic.json
@@ -1,7 +1,7 @@
 {
   "name": "cosmic",
   "summary": "COSMIC Desktop",
-  "description": "Stable: But still under active development",
+  "description": "Stable, but still under active development",
   "display": true,
   "priority": 30,
   "depends": ["base-desktop"],


### PR DESCRIPTION
Created a quick PR to change the description for Cosmic to highlight that it is stable but still behind Gnome and KDE Plasma which show "Recommended for most users"