### PR TITLE
Fix first-boot, update selections

### DIFF
--- a/crates/installer/src/steps/mod.rs
+++ b/crates/installer/src/steps/mod.rs
@@ -35,7 +35,7 @@ pub enum Step<'a> {
     Mount(Box<MountPartition<'a>>),
     SetPassword(Box<SetPassword<'a>>),
     SetLocale(Box<SetLocale<'a>>),
-    SetMachineID(Box<SetMachineID>),
+    ResetMachineID(Box<ResetMachineID>),
     SetTimezone(Box<SetTimezone<'a>>),
     WriteFstab(Box<EmitFstab>),
 }
@@ -86,7 +86,7 @@ impl<'a> Step<'a> {
 
     /// Construct a dbus/systemd machine id
     pub fn set_machine_id() -> Self {
-        Self::SetMachineID(Box::new(SetMachineID {}))
+        Self::ResetMachineID(Box::new(ResetMachineID {}))
     }
 
     // Emit the given fstab
@@ -106,7 +106,7 @@ impl<'a> Step<'a> {
             Step::SetPassword(_) => "set-password",
             Step::SetLocale(_) => "set-locale",
             Step::SetTimezone(_) => "set-timezone",
-            Step::SetMachineID(_) => "set-machine-id",
+            Step::ResetMachineID(_) => "reset-machine-id",
             Step::WriteFstab(_) => "write-fstab",
         }
     }
@@ -123,7 +123,7 @@ impl<'a> Step<'a> {
             Step::SetPassword(s) => s.title(),
             Step::SetLocale(s) => s.title(),
             Step::SetTimezone(s) => s.title(),
-            Step::SetMachineID(s) => s.title(),
+            Step::ResetMachineID(s) => s.title(),
             Step::WriteFstab(s) => s.title(),
         }
     }
@@ -140,7 +140,7 @@ impl<'a> Step<'a> {
             Step::SetPassword(s) => s.describe(),
             Step::SetLocale(s) => s.describe(),
             Step::SetTimezone(s) => s.describe(),
-            Step::SetMachineID(s) => s.describe(),
+            Step::ResetMachineID(s) => s.describe(),
             Step::WriteFstab(s) => s.describe(),
         }
     }
@@ -157,7 +157,7 @@ impl<'a> Step<'a> {
             Step::SetPassword(s) => Ok(s.execute(context)?),
             Step::SetLocale(s) => Ok(s.execute(context)?),
             Step::SetTimezone(s) => Ok(s.execute(context)?),
-            Step::SetMachineID(s) => Ok(s.execute(context)?),
+            Step::ResetMachineID(s) => Ok(s.execute(context)?),
             Step::WriteFstab(s) => Ok(s.execute(context)?),
         }
     }
@@ -180,4 +180,4 @@ mod cleanup;
 pub use cleanup::Cleanup;
 
 mod postinstall;
-pub use postinstall::{CreateAccount, EmitFstab, FstabEntry, SetLocale, SetMachineID, SetPassword, SetTimezone};
+pub use postinstall::{CreateAccount, EmitFstab, FstabEntry, ResetMachineID, SetLocale, SetPassword, SetTimezone};

--- a/crates/installer/src/steps/postinstall.rs
+++ b/crates/installer/src/steps/postinstall.rs
@@ -125,17 +125,17 @@ impl<'a> SetTimezone<'a> {
     }
 }
 
-/// Set a machine ID up in the root
+/// Delete an existing machine-id so that systemd detects the first boot (and creates the file then)
 #[derive(Debug)]
-pub struct SetMachineID {}
+pub struct ResetMachineID {}
 
-impl<'a> SetMachineID {
+impl<'a> ResetMachineID {
     pub(super) fn title(&self) -> String {
-        "Allocate machine-id".to_string()
+        "Reset machine-id".to_string()
     }
 
     pub(super) fn describe(&self) -> String {
-        "via systemd-machine-id-setup".to_string()
+        "via first-boot".to_string()
     }
 
     pub(super) fn execute(&self, context: &'a impl Context<'a>) -> Result<(), Error> {
@@ -143,11 +143,6 @@ impl<'a> SetMachineID {
         if file.exists() {
             fs::remove_file(file)?;
         }
-
-        let mut cmd = Command::new("chroot");
-        cmd.arg(context.root().clone());
-        cmd.arg("systemd-machine-id-setup");
-        context.run_command_captured(&mut cmd, None)?;
 
         Ok(())
     }

--- a/selections/base-desktop.json
+++ b/selections/base-desktop.json
@@ -15,6 +15,7 @@
     "liberation-fonts-ttf",
     "scx-tools",
     "sysbinary(plymouthd)",
+    "system76-scheduler",
     "pkgset-aeryn-base-desktop",
     "zram-generator-defaults"
   ]

--- a/selections/kernel-desktop.json
+++ b/selections/kernel-desktop.json
@@ -6,7 +6,7 @@
     "kernel-common"
   ],
   "required": [
-    "linux-desktop",
+    "linux-stable",
     "linux-firmware",
     "linux-firmware-amd-graphics",
     "linux-firmware-atheros",


### PR DESCRIPTION
- Don't create the machine-id file during install which ensures that the following boot is properly considered the first-boot by systemd
- Update selections to install linux-stable instead of linux-deskop and install system76-scheduler.